### PR TITLE
fix cas in middleware

### DIFF
--- a/pod_project/pod_project/settings-sample.py
+++ b/pod_project/pod_project/settings-sample.py
@@ -62,8 +62,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     # Pages statiques
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    # CAS
-    'django_cas_gateway.middleware.CASMiddleware'
 )
 
 ROOT_URLCONF = 'pod_project.urls'


### PR DESCRIPTION
- remove 'django_cas_gateway.middleware.CASMiddleware' in settings sample to add it only if cas is used