### PR TITLE
Feature: I18n L10n mods #2

### DIFF
--- a/pod_project/core/templates/userProfile.html
+++ b/pod_project/core/templates/userProfile.html
@@ -62,7 +62,7 @@ var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you h
     {% block article_content %}
 
 {% if form.errors %}
-<!-- <p>{% trans "errors have been found in the form" %}</p> -->
+<!-- <p>{% trans "One or more errors have been found in the form." %}</p> -->
 {% endif %}
 
 <form method="post" action="{% url 'user_profile' %}">

--- a/pod_project/core/views.py
+++ b/pod_project/core/views.py
@@ -163,7 +163,7 @@ def user_profile(request):
                 request, messages.INFO, _(u'Your profile is saved.'))
         else:
             messages.add_message(
-                request, messages.ERROR, _(u'Error in the form.'))
+                request, messages.ERROR, _(u'One or more errors have been found in the form.'))
 
     return render_to_response("userProfile.html",
                               {'form': profile_form, },

--- a/pod_project/pods/models.py
+++ b/pod_project/pods/models.py
@@ -498,7 +498,7 @@ class TrackPods(models.Model):
         ("", settings.PREF_LANG_CHOICES), ("-----------", settings.ALL_LANG_CHOICES))
     lang = models.CharField(_('Language'), max_length=2, choices=LANG_CHOICES)
     src = FilerFileField(
-        null=True, blank=True, verbose_name=_("sub-heading file"))
+        null=True, blank=True, verbose_name=_("subtitle file"))
 
     class Meta:
         verbose_name = _("Track Pod")

--- a/pod_project/pods/templates/channels/channel_edit.html
+++ b/pod_project/pods/templates/channels/channel_edit.html
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -34,7 +34,7 @@ voir http://www.gnu.org/licenses/
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
         <script type="text/javascript" src="{{ STATIC_URL }}admin/js/actions.js"></script>
-        
+
         <!-- form.media -->
         {{form.media}}
         <!-- {{formset.media}} -->
@@ -72,10 +72,10 @@ jQuery(function($) {
 
 {% block article %}
     {% block article_content %}
-        
-    
+
+
 {% if form.errors %}
-<p> {% trans "Warning, errors have been found in the form" %}</p>
+<p> {% trans "One or more errors have been found in the form." %}</p>
 {{form.errors}}
 {% endif %}
 
@@ -106,7 +106,7 @@ jQuery(function($) {
     <legend>{% trans "Themes" %}</legend>
     <div id="formset" data-formset-prefix="{{ formset.prefix }}">
         {{ formset.management_form }}
-    
+
         <div data-formset-body class="data-formset-body" >
             <!-- New forms will be inserted in here -->
             {% for form in formset %}
@@ -131,7 +131,7 @@ jQuery(function($) {
                 </div>
             {% endfor %}
         </div>
-    
+
         <!-- The empty form template. By wrapping this in a <script> tag, the
         __prefix__ placeholder can easily be replaced in both attributes and
         any scripts -->
@@ -158,7 +158,7 @@ jQuery(function($) {
                 </div>
             {% endescapescript %}
         </script>
-    
+
         <!-- This button will add a new form when clicked -->
         <p>&nbsp;</p>
         <div class="text-center">
@@ -181,7 +181,7 @@ jQuery(function($) {
     </button>
 </div>
 {% endbuttons %}
-    
+
     </form>
     {% endblock article_content %}
     {% block video_list %} {% endblock video_list %}

--- a/pod_project/pods/templates/mediacourses/mediacourses_add.html
+++ b/pod_project/pods/templates/mediacourses/mediacourses_add.html
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -50,7 +50,7 @@ var messageBeforeUnload = "{% trans "Warning, you will leave this page. If you h
     {% block article_content %}
 
 {% if form.errors %}
-<p> {% trans "Warning, errors have been found in the form" %}</p>
+<p> {% trans "One or more errors have been found in the form." %}</p>
 {{form.errors}}
 {% endif %}
 

--- a/pod_project/pods/templates/search/search.html
+++ b/pod_project/pods/templates/search/search.html
@@ -6,7 +6,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -56,7 +56,7 @@ voir http://www.gnu.org/licenses/
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content="{{ request.build_absolute_uri }}" />
 	<meta property="og:image" content="//{{ request.META.HTTP_HOST }}{% static 'images/share.png' %}" />
-	<meta property="og:description" content="{{ query }}" /> 
+	<meta property="og:description" content="{{ query }}" />
 	<meta property="og:site_name" content="{{ TITLE_SITE }}" />
 {% endblock opengraph %}
 
@@ -133,21 +133,21 @@ voir http://www.gnu.org/licenses/
                             </a>
                             {% if user.is_authenticated and result.object.owner == request.user%}
                                 <span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! -->
-                                    <a href="{% url 'video_edit' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Edit' %}">
+                                    <a href="{% url 'video_edit' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Edit video information.' %}">
                                         <span class="glyphicon glyphicon-pencil"></span>
                                         <span class="sr-only">{% trans 'Edit' %}</span>
                                     </a>
-                                    <a href="{% url 'video_chapter' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Chapter' %}">
-                                        <span class="glyphicon glyphicon-list"></span>
-                                        <span class="sr-only">{% trans 'Chapter' %}</span>
-                                    </a>
-                                    <a href="{% url 'video_enrich' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Enrich' %}">
-                                        <span class="glyphicon glyphicon-file"></span>
-                                        <span class="sr-only">{% trans 'Enrich' %}</span>
-                                    </a>
-                                    <a href="{% url 'video_completion' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subtitles, contributors, download documents' %}">
+                                    <a href="{% url 'video_completion' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subheading, contributors, documents to download.' %}">
                                         <span class="glyphicon glyphicon-paperclip"></span>
                                         <span class="sr-only">{% trans 'Completion' %}</span>
+                                    </a>
+                                    <a href="{% url 'video_chapter' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Divide the video into chapters.' %}">
+                                        <span class="glyphicon glyphicon-list"></span>
+                                        <span class="sr-only">{% trans 'Chaptering' %}</span>
+                                    </a>
+                                    <a href="{% url 'video_enrich' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add enrichments to the video.' %}">
+                                        <span class="glyphicon glyphicon-file"></span>
+                                        <span class="sr-only">{% trans 'Enrich' %}</span>
                                     </a>
                                     {% if not result.object.encoding_in_progress %}
                                         <a href="{% url 'video_delete' slug=result.object.slug %}" class="btn btn-danger btn-xs" title="{% trans 'Delete' %}">

--- a/pod_project/pods/templates/search/search.html
+++ b/pod_project/pods/templates/search/search.html
@@ -137,7 +137,7 @@ voir http://www.gnu.org/licenses/
                                         <span class="glyphicon glyphicon-pencil"></span>
                                         <span class="sr-only">{% trans 'Edit' %}</span>
                                     </a>
-                                    <a href="{% url 'video_completion' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subheading, contributors, documents to download.' %}">
+                                    <a href="{% url 'video_completion' slug=result.object.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subtitle files, contributors, documents to download.' %}">
                                         <span class="glyphicon glyphicon-paperclip"></span>
                                         <span class="sr-only">{% trans 'Completion' %}</span>
                                     </a>

--- a/pod_project/pods/templates/videos/chapter/form_chapter.html
+++ b/pod_project/pods/templates/videos/chapter/form_chapter.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
     {% csrf_token %}
     <div id="formcontent" class="form-container">
         {% if form_chapter.errors or form_chapter.non_field_errors %}
-            {% trans "Your form contains errors:" %} <br/>
+            {% trans "One or more errors have been found in the form:" %} <br/>
             {% for error in form_chapter.non_field_errors %}
                 - {{error}} <br/>
             {%endfor%}

--- a/pod_project/pods/templates/videos/enrich/form_enrich.html
+++ b/pod_project/pods/templates/videos/enrich/form_enrich.html
@@ -24,7 +24,7 @@ voir http://www.gnu.org/licenses/
     {% csrf_token %}
     <div id="formcontent" class="form-container">
         {% if form_enrich.errors or form_enrich.non_field_errors %}
-            {% trans "Your form contains errors:" %} <br/>
+            {% trans "One or more errors have been found in the form:" %} <br/>
             {% for error in form_enrich.non_field_errors %}
                 - {{error}} <br/>
             {%endfor%}

--- a/pod_project/pods/templates/videos/ownertools.html
+++ b/pod_project/pods/templates/videos/ownertools.html
@@ -25,7 +25,7 @@ voir http://www.gnu.org/licenses/
   <span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans "Edit" %}</span>
 </a>
 
-<a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add subheading, contributors, documents to download."%}">
+<a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add subtitle files, contributors, documents to download."%}">
   <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans "Completion" %}</span>
 </a>
 

--- a/pod_project/pods/templates/videos/ownertools.html
+++ b/pod_project/pods/templates/videos/ownertools.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -21,28 +21,28 @@ voir http://www.gnu.org/licenses/
 {% load i18n %}
 {% if video and video.slug != "" %}
 <span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! -->
-<a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Edit" %}">
+<a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Edit video information." %}">
   <span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans "Edit" %}</span>
 </a>
 
-<a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add subtitles, contributors, download documents"%}">
-  <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans "Completion the video" %}</span>
+<a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add subheading, contributors, documents to download."%}">
+  <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans "Completion" %}</span>
 </a>
 
-<a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Chapter the video" %}">
-  <span class="glyphicon glyphicon-list"></span><span class="sr-only">{% trans "Chapter the video" %}</span>
+<a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Divide the video into chapters." %}">
+  <span class="glyphicon glyphicon-list"></span><span class="sr-only">{% trans "Chaptering" %}</span>
 </a>
 {%if user.is_staff%}
-<a href="{% url 'video_enrich' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Enrich the video" %}">
-  <span class="glyphicon glyphicon-file"></span><span class="sr-only">{% trans "Enrich the video" %}</span>
+<a href="{% url 'video_enrich' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Add enrichments to the video." %}">
+  <span class="glyphicon glyphicon-file"></span><span class="sr-only">{% trans "Enrich" %}</span>
 </a>
 {%endif%}
-<a href="{% url 'video' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Watch the video" %}">
-  <span class="glyphicon glyphicon-film"></span><span class="sr-only">{% trans "Watch the video" %}</span>
+<a href="{% url 'video' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans "Watch the video." %}">
+  <span class="glyphicon glyphicon-film"></span><span class="sr-only">{% trans "Watch" %}</span>
 </a>
 {% if not video.encoding_in_progress %}
-<a href="{% url 'video_delete' slug=video.slug %}" class="btn btn-danger btn-xs" title="{% trans "Delete the video" %}">
-  <span class="glyphicon glyphicon-remove"></span><span class="sr-only">{% trans "Delete the video" %}</span>
+<a href="{% url 'video_delete' slug=video.slug %}" class="btn btn-danger btn-xs" title="{% trans "Delete the video." %}">
+  <span class="glyphicon glyphicon-remove"></span><span class="sr-only">{% trans "Delete" %}</span>
 </a>
 {%endif%}
 </span>

--- a/pod_project/pods/templates/videos/video_chapter.html
+++ b/pod_project/pods/templates/videos/video_chapter.html
@@ -26,7 +26,7 @@ voir http://www.gnu.org/licenses/
 {% load bootstrap3 %}
 
 {% block bootstrap3_title%}
-{% trans "Chaptering of the video" %} "{{video.title}}"
+{% trans "Chaptering the video" %} "{{video.title}}"
 {% endblock bootstrap3_title%}
 
 {% block bootstrap3_extra_head %}
@@ -326,7 +326,7 @@ $(document).on('click','#page-video span.getfromvideo a',function(e) {
 
 {% endblock bootstrap3_extra_head %}
 
-{% block article_title %}{% trans "Chaptering of the video" %} "{{video.title}}"{% endblock %}
+{% block article_title %}{% trans "Chaptering the video" %} "{{video.title}}"{% endblock %}
 
 {% block mainToolbar %}
 {% endblock mainToolbar %}
@@ -337,7 +337,7 @@ $(document).on('click','#page-video span.getfromvideo a',function(e) {
         {% block breadcrumbs %}
         {{ block.super }}
         <li><a href="{% url 'owner_videos_list' %}">{% trans "My videos" %}</a></li>
-        <li class="active"> {% trans "Chaptering of the video" %} "{{video.title}}"</li>
+        <li class="active"> {% trans "Chaptering the video" %} "{{video.title}}"</li>
         {% endblock breadcrumbs %}
     </ol>
 

--- a/pod_project/pods/templates/videos/video_chapter.html
+++ b/pod_project/pods/templates/videos/video_chapter.html
@@ -254,7 +254,7 @@ $(document).on("submit", "#page-video form", function (e) {
                 });
             }
         }else{
-            show_messages("{% trans 'Errors found in the form, please correct it.' %}"+button, false, 'alert-danger');
+            show_messages("{% trans 'One or more errors have been found in the form.' %}"+button, false, 'alert-danger');
         }
 
     }

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -173,7 +173,7 @@ var name = "";
 
 
 {% if form.errors %}
-<p> {% trans "Errors have been found in the form." %}</p>
+<p> {% trans "One or more errors have been found in the form." %}</p>
 {{form.errors}}
 {% endif %}
 

--- a/pod_project/pods/templates/videos/video_edit.html
+++ b/pod_project/pods/templates/videos/video_edit.html
@@ -103,9 +103,9 @@ $(document).ready(function() {
 		messages: {
 		    {% if not form.instance.video %}
 			video: {
-				required: "{% trans "Video field is required" %}",
-				/*accept: "{% trans "The mime type is wrong" %}",*/
-				extension: "{% trans "Wrong format." %}",
+				required: "{% trans "Video field is required." %}",
+				/*accept: "{% trans "Wrong MIME type." %}",*/
+				extension: "{% trans "File format not allowed." %}",
 			},
 			{% endif %}
 			title: {

--- a/pod_project/pods/templates/videos/video_enrich.html
+++ b/pod_project/pods/templates/videos/video_enrich.html
@@ -245,7 +245,7 @@ $(document).on("submit", "#page-video form", function (e) {
                 });
             }
         }else{
-            show_messages("{% trans 'Errors found in the form, please correct it.' %}"+button, false, 'alert-danger');
+            show_messages("{% trans 'One or more errors have been found in the form.' %}"+button, false, 'alert-danger');
         }
     }
 

--- a/pod_project/pods/templates/videos/videos_list.html
+++ b/pod_project/pods/templates/videos/videos_list.html
@@ -86,7 +86,7 @@ voir http://www.gnu.org/licenses/
                     <a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Edit video information.' %}">
                         <span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans 'Edit' %}</span>
                     </a>
-                    <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subheading, contributors, documents to download.' %}">
+                    <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subtitle files, contributors, documents to download.' %}">
                         <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans 'Completion' %}</span>
                     </a>
                     <a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Divide the video into chapters.' %}">

--- a/pod_project/pods/templates/videos/videos_list.html
+++ b/pod_project/pods/templates/videos/videos_list.html
@@ -5,7 +5,7 @@ le redistribuer et/ou le modifier sous les termes
 de la licence GNU Public Licence telle que publiée
 par la Free Software Foundation, soit dans la
 version 3 de la licence, ou (selon votre choix)
-toute version ultérieure. 
+toute version ultérieure.
 Ce programme est distribué avec l'espoir
 qu'il sera utile, mais SANS AUCUNE
 GARANTIE : sans même les garanties
@@ -83,17 +83,17 @@ voir http://www.gnu.org/licenses/
             </a>
             {% if user.is_authenticated and video.owner == request.user %}
                 <span class="user-tools hidden-xs"><!-- ONLY VISIBLE TO THE VIDEO OWNER ! -->
-                    <a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Edit' %}">
+                    <a href="{% url 'video_edit' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Edit video information.' %}">
                         <span class="glyphicon glyphicon-pencil"></span><span class="sr-only">{% trans 'Edit' %}</span>
                     </a>
-                    <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subtitles, contributors, download documents' %}">
+                    <a href="{% url 'video_completion' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add subheading, contributors, documents to download.' %}">
                         <span class="glyphicon glyphicon-paperclip"></span><span class="sr-only">{% trans 'Completion' %}</span>
                     </a>
-                    <a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Chapter' %}">
-                        <span class="glyphicon glyphicon-list"></span><span class="sr-only">{% trans 'Chapter' %}</span>
+                    <a href="{% url 'video_chapter' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Divide the video into chapters.' %}">
+                        <span class="glyphicon glyphicon-list"></span><span class="sr-only">{% trans 'Chaptering' %}</span>
                     </a>
                     {% if user.is_staff %}
-                        <a href="{% url 'video_enrich' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Enrich' %}">
+                        <a href="{% url 'video_enrich' slug=video.slug %}" class="btn btn-default btn-xs" title="{% trans 'Add enrichments to the video.' %}">
                             <span class="glyphicon glyphicon-file"></span><span class="sr-only">{% trans 'Enrich' %}</span>
                         </a>
                     {% endif %}

--- a/pod_project/pods/views.py
+++ b/pod_project/pods/views.py
@@ -185,7 +185,7 @@ def channel_edit(request, slug_c):
                 return HttpResponseRedirect(reverse('pods.views.channel', args=(channel.slug,)))
         else:
             messages.add_message(
-                request, messages.ERROR, _(u'Error in the form.'))
+                request, messages.ERROR, _(u'One or more errors have been found in the form.'))
 
     formset = ThemeInlineFormSet(instance=channel)   # MAJ...
     return render_to_response("channels/channel_edit.html",
@@ -455,7 +455,7 @@ def video(request, slug, slug_c=None, slug_t=None):
                     )
             else:
                 messages.add_message(
-                    request, messages.ERROR, _(u'Error in the form.'))
+                    request, messages.ERROR, _(u'One or more errors have been found in the form.'))
                 return render_to_response(
                     'videos/video.html',
                     {'video': video, 'form': form, 'channel': channel,
@@ -675,7 +675,7 @@ def video_edit(request, slug=None):
                 return HttpResponseRedirect(reverse('pods.views.video_edit', args=(vid.slug,)))
         else:
             messages.add_message(
-                request, messages.ERROR, _(u'Error in the form.'))
+                request, messages.ERROR, _(u'One or more errors have been found in the form.'))
 
     video_ext_accept = replace(' | '.join(settings.VIDEO_EXT_ACCEPT), ".", "")
 
@@ -744,7 +744,7 @@ def video_completion(request, slug):
                 # args=(video.slug,)))
             else:
                 messages.add_message(
-                    request, messages.ERROR, _(u'Error in the form.'))
+                    request, messages.ERROR, _(u'One or more errors have been found in the form.'))
         else:
             contributorformset = ContributorInlineFormSet(
                 request.POST, instance=video, prefix='contributor_form')
@@ -769,7 +769,7 @@ def video_completion(request, slug):
                 # args=(video.slug,)))
             else:
                 messages.add_message(
-                    request, messages.ERROR, _(u'Error in the form.'))
+                    request, messages.ERROR, _(u'One or more errors have been found in the form.'))
     else:
         contributorformset = ContributorInlineFormSet(
             instance=video, prefix='contributor_form')
@@ -1153,7 +1153,7 @@ def mediacourses(request):
             messages.add_message(request, messages.INFO, message)
             return HttpResponseRedirect(reverse('pods.views.owner_videos_list'))
         else:
-            message = _('Error in the form.')
+            message = _('One or more errors have been found in the form.')
             messages.add_message(request, messages.ERROR, message)
 
     return render_to_response("mediacourses/mediacourses_add.html",

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-06-25 17:36+0200\n"
-"PO-Revision-Date: 2015-07-01 18:22+0200\n"
+"PO-Revision-Date: 2015-07-02 17:33+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -303,6 +303,7 @@ msgstr "Supprimer '%(item_label)s'."
 #: pods/templates/videos/video_delete.html:73
 #: pods/templates/videos/videos_list.html:101
 #: pods/templates/videos/videos_list.html:102
+#: pods/templates/videos/ownertools.html:45
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1923,29 +1924,21 @@ msgstr "Afficher tous"
 
 #: pods/templates/search/search.html:136 pods/templates/search/search.html:138
 #: pods/templates/search/search.html:179
-#: pods/templates/videos/ownertools.html:24
-#: pods/templates/videos/ownertools.html:25
 #: pods/templates/videos/videos_list.html:86
 #: pods/templates/videos/videos_list.html:87
 msgid "Edit"
 msgstr "Modifier"
 
-#: pods/templates/search/search.html:144 pods/templates/search/search.html:146
-#: pods/templates/videos/videos_list.html:96
-#: pods/templates/videos/videos_list.html:97
-msgid "Enrich"
-msgstr "Enrichir la vidéo"
+#: pods/templates/videos/ownertools.html:24
+#: pods/templates/videos/ownertools.html:25
+msgid "Edit video information."
+msgstr "Modifier les informations de la vidéo."
 
 #: pods/templates/search/search.html:148
 #: pods/templates/videos/ownertools.html:28
 #: pods/templates/videos/videos_list.html:89
-msgid "Add subtitles, contributors, download documents"
-msgstr "Ajouter des sous-titres, contributeurs, documents à télécharger"
-
-#: pods/templates/search/search.html:150
-#: pods/templates/videos/videos_list.html:90
-msgid "Completion"
-msgstr "Complétion de la vidéo"
+msgid "Add subheading, contributors, documents to download."
+msgstr "Ajouter des sous-titres, contributeurs, documents à télécharger."
 
 #: pods/templates/search/search.html:176
 msgid "Advanced Search"
@@ -1988,26 +1981,42 @@ msgid "Use the thumbnails toolbar to work on a video."
 msgstr "Utilisez la barre d'outils pour travailler sur une vidéo."
 
 #: pods/templates/videos/ownertools.html:29
-msgid "Completion the video"
-msgstr "Complétion de la vidéo"
+#: pods/templates/search/search.html:150
+#: pods/templates/videos/videos_list.html:90
+msgid "Completion"
+msgstr "Complétion"
 
 #: pods/templates/videos/ownertools.html:32
+msgid "Divide the video into chapters."
+msgstr "Diviser la video en chapitres."
+
 #: pods/templates/videos/ownertools.html:33
-msgid "Chapter the video"
-msgstr "Chapitrer la vidéo"
+msgid "Chaptering"
+msgstr "Chapitrage"
 
 #: pods/templates/videos/ownertools.html:36
+msgid "Add enrichments to the video."
+msgstr "Ajouter des enrichissements à la vidéo."
+
 #: pods/templates/videos/ownertools.html:37
-msgid "Enrich the video"
-msgstr "Enrichir la vidéo"
+#: pods/templates/search/search.html:144 pods/templates/search/search.html:146
+#: pods/templates/videos/videos_list.html:96
+#: pods/templates/videos/videos_list.html:97
+msgid "Enrich"
+msgstr "Enrichir"
 
 #: pods/templates/videos/ownertools.html:40
+msgid "Watch the video."
+msgstr "Regarder la vidéo."
+
 #: pods/templates/videos/ownertools.html:41
-msgid "Watch the video"
-msgstr "Regarder la vidéo"
+msgid "Watch"
+msgstr "Regarder"
 
 #: pods/templates/videos/ownertools.html:44
-#: pods/templates/videos/ownertools.html:45
+msgid "Delete the video."
+msgstr "Supprimer la vidéo."
+
 #: pods/templates/videos/video_delete.html:26
 #: pods/templates/videos/video_delete.html:35
 #: pods/templates/videos/video_delete.html:41

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-06-25 17:36+0200\n"
-"PO-Revision-Date: 2015-06-25 18:10+0100\n"
+"PO-Revision-Date: 2015-07-01 17:38+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 1.8.1\n"
+"X-Generator: Poedit 1.8.2\n"
 
 #: core/models.py:68
 msgid "order"
@@ -2723,103 +2723,3 @@ msgstr ""
 msgid "New mediacourse added."
 msgstr "Nouveaux médiacours ajoutés."
 
-#, fuzzy
-#~| msgid "Save and back to previous page"
-#~ msgid "Save and back to the previous page"
-#~ msgstr "Enregistrer et revenir à la page précédente"
-
-#, fuzzy
-#~| msgid "Please enter a correct image."
-#~ msgid "Please enter a correct type."
-#~ msgstr "Veuillez renseigner une image."
-
-#, fuzzy
-#~| msgid "The changes have been saved."
-#~ msgid "The changes have been saved"
-#~ msgstr "Les modifications ont été enregistrées."
-
-#, fuzzy
-#~| msgid "Please enter a title from 2 to 100 characters."
-#~ msgid "Please enter a title from 2 to 100 caracteres."
-#~ msgstr "Veuillez renseigner un titre contenant entre 2 et 100 caractères."
-
-#~ msgid "error post request"
-#~ msgstr "Erreur lors de la requête"
-
-#, fuzzy
-#~| msgid "Chaptering video"
-#~ msgid "Chapter video"
-#~ msgstr "Chapitrer la vidéo"
-
-#~ msgid "Creation date"
-#~ msgstr "Date d'ajout"
-
-#~ msgid "Add new video"
-#~ msgstr "Ajouter une nouvelle vidéo"
-
-#~ msgid "Stop"
-#~ msgstr "Fin"
-
-#~ msgid ""
-#~ "Start and end fields must contain a value in seconds. You can use the "
-#~ "\"get time from the player\" button to fill it with the current time of "
-#~ "the player in the video."
-#~ msgstr ""
-#~ "Les champs début et fin doivent contenir une valeur en seconde. Vous "
-#~ "pouvez utiliser le bouton \"récupérer le temps depuis le lecteur\" pour "
-#~ "le remplir avec la position du lecteur dans la vidéo."
-
-#~ msgid ""
-#~ "\"Add a new enrichment\" to add a new enrichment and \"delete\" removes "
-#~ "enrichment."
-#~ msgstr ""
-#~ "\"Ajouter un nouvel enrichissement\" permet d'ajouter un nouvel "
-#~ "enrichissement et \"supprimer\" supprime l'enrichissement."
-
-#~ msgid "Click on modify button of enrichment to modify its properties."
-#~ msgstr "Cliquer sur le bouton modifier pour changer ses propriétés."
-
-#~ msgid ""
-#~ "Please ensure that each enrich contains a title, timecode start, end, and "
-#~ "the end timecode is higher than at the beginning."
-#~ msgstr ""
-#~ "Veuillez vous assurer que chaque enrichissement contient un titre, un "
-#~ "début, une fin et que le timecode de fin est plus élevé que celui du "
-#~ "début."
-
-#~ msgid "Error in enrich"
-#~ msgstr "Erreur dans l'enrichissement"
-
-#~ msgid "\"Add\" to add a new enrichment and \"delete\" removes enrichment."
-#~ msgstr ""
-#~ "\"Ajouter\" permet d'ajouter un nouvel enrichissement et \"supprimer\" "
-#~ "supprime l'enrichissement."
-
-#~ msgid "Click on a display range of enrichment to modify its properties."
-#~ msgstr ""
-#~ "Cliquer sur une plage d'affichage de l'enrichissement (barre jaune sur la "
-#~ "barre de lecture) pour modifier ses propriétés."
-
-#~ msgid ""
-#~ "Use the yellow tabs on the play bar to set the display enrichment beach."
-#~ msgstr ""
-#~ "Utilisez les ergots jaunes de la barre de lecture pour définir la plage "
-#~ "d'affichage de l'enrichissement."
-
-#~ msgid "end should be greater than start"
-#~ msgstr "la fin doit être supérieur au début"
-
-#~ msgid "Run the selected action"
-#~ msgstr "lancer cette action"
-
-#~ msgid "Go"
-#~ msgstr "Ok"
-
-#~ msgid "Click here to select the objects across all pages"
-#~ msgstr "Cliquez ici pour sélectionner les objets dans toutes les pages"
-
-#~ msgid "Edit your videos"
-#~ msgstr "Modifier vos vidéos"
-
-#~ msgid "Discipline "
-#~ msgstr "Discipline"

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-02 18:08+0200\n"
-"PO-Revision-Date: 2015-07-03 14:15+0200\n"
+"POT-Creation-Date: 2015-07-03 14:35+0200\n"
+"PO-Revision-Date: 2015-07-03 14:37+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -661,20 +661,16 @@ msgstr ""
 msgid "My Profile"
 msgstr "Mon profil"
 
-#: core/templates/userProfile.html:65 core/views.py:166 pods/views.py:188
-#: pods/views.py:458 pods/views.py:678 pods/views.py:747 pods/views.py:772
-#: pods/views.py:1156 pods/templates/channels/channel_edit.html:78
+#: core/templates/userProfile.html:65 core/views.py:166
+#: pods/templates/channels/channel_edit.html:78
 #: pods/templates/mediacourses/mediacourses_add.html:53
 #: pods/templates/videos/video_chapter.html:257
-#: pods/templates/videos/video_enrich.html:248
 #: pods/templates/videos/video_edit.html:176
+#: pods/templates/videos/video_enrich.html:248 pods/views.py:188
+#: pods/views.py:458 pods/views.py:678 pods/views.py:747 pods/views.py:772
+#: pods/views.py:1156
 msgid "One or more errors have been found in the form."
 msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire."
-
-#: pods/templates/videos/chapter/form_chapter.html:27
-#: pods/templates/videos/enrich/form_enrich.html:27
-msgid "One or more errors have been found in the form:"
-msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire :"
 
 #: core/templates/userProfile.html:77
 #: pods/templates/videos/chapter/form_chapter.html:44
@@ -1975,6 +1971,11 @@ msgstr "Recherche avancée"
 #: pods/templates/search/search.html:191
 msgid "faceting"
 msgstr "Affiner"
+
+#: pods/templates/videos/chapter/form_chapter.html:27
+#: pods/templates/videos/enrich/form_enrich.html:27
+msgid "One or more errors have been found in the form:"
+msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire :"
 
 #: pods/templates/videos/chapter/list_chapter.html:26
 msgid "List of chapters"

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-02 18:08+0200\n"
-"PO-Revision-Date: 2015-07-03 11:58+0200\n"
+"PO-Revision-Date: 2015-07-03 13:53+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -2356,16 +2356,16 @@ msgid "Editing the video"
 msgstr "Modification de la vidéo"
 
 #: pods/templates/videos/video_edit.html:106
-msgid "Video field is required"
-msgstr "Le champ vidéo est obligatoire"
+msgid "Video field is required."
+msgstr "Le champ vidéo est obligatoire."
 
 #: pods/templates/videos/video_edit.html:107
-msgid "The mime type is wrong"
-msgstr "Le type MIME est faux"
+msgid "Wrong MIME type."
+msgstr "Le type MIME ne correspond pas."
 
 #: pods/templates/videos/video_edit.html:108
-msgid "Wrong format."
-msgstr "Format non autorisé"
+msgid "File format not allowed."
+msgstr "Format non autorisé."
 
 #: pods/templates/videos/video_edit.html:112
 msgid "Please, specify a title."

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-06-25 17:36+0200\n"
-"PO-Revision-Date: 2015-07-01 17:38+0200\n"
+"PO-Revision-Date: 2015-07-01 18:22+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -1549,7 +1549,7 @@ msgstr "Documents"
 
 #: pods/models.py:543
 msgid "Stop video"
-msgstr "Stop video"
+msgstr "Arrêter la lecture"
 
 #: pods/models.py:544
 msgid "The video will pause when displaying this enrichment."
@@ -2722,4 +2722,3 @@ msgstr ""
 #: pods/views.py:1222
 msgid "New mediacourse added."
 msgstr "Nouveaux médiacours ajoutés."
-

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-02 18:08+0200\n"
-"PO-Revision-Date: 2015-07-03 11:55+0200\n"
+"PO-Revision-Date: 2015-07-03 11:58+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -2177,7 +2177,7 @@ msgstr "Erreur lors de l'enregistrement."
 #: pods/templates/videos/video_chapter.html:253
 #: pods/templates/videos/video_enrich.html:244
 msgid "No data could be stored."
-msgstr "Aucune données enregistrées"
+msgstr "Aucune donnée n'a pu être enregistrée."
 
 #: pods/templates/videos/video_chapter.html:273
 #: pods/templates/videos/video_enrich.html:268 pods/views.py:178

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-02 18:08+0200\n"
-"PO-Revision-Date: 2015-07-03 11:24+0200\n"
+"PO-Revision-Date: 2015-07-03 11:55+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -661,9 +661,20 @@ msgstr ""
 msgid "My Profile"
 msgstr "Mon profil"
 
-#: core/templates/userProfile.html:65
-msgid "errors have been found in the form"
-msgstr "Erreur dans le formulaire"
+#: core/templates/userProfile.html:65 core/views.py:166 pods/views.py:188
+#: pods/views.py:458 pods/views.py:678 pods/views.py:747 pods/views.py:772
+#: pods/views.py:1156 pods/templates/channels/channel_edit.html:78
+#: pods/templates/mediacourses/mediacourses_add.html:53
+#: pods/templates/videos/video_chapter.html:257
+#: pods/templates/videos/video_enrich.html:248
+#: pods/templates/videos/video_edit.html:176
+msgid "One or more errors have been found in the form."
+msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire."
+
+#: pods/templates/videos/chapter/form_chapter.html:27
+#: pods/templates/videos/enrich/form_enrich.html:27
+msgid "One or more errors have been found in the form:"
+msgstr "Une ou plusieurs erreurs ont été trouvées dans le formulaire :"
 
 #: core/templates/userProfile.html:77
 #: pods/templates/videos/chapter/form_chapter.html:44
@@ -706,11 +717,6 @@ msgstr ""
 #: core/views.py:163
 msgid "Your profile is saved."
 msgstr "Votre profil est enregistré."
-
-#: core/views.py:166 pods/views.py:188 pods/views.py:458 pods/views.py:678
-#: pods/views.py:747 pods/views.py:772 pods/views.py:1156
-msgid "Error in the form."
-msgstr "Erreur dans le formulaire."
 
 #: django_cas_gateway/views.py:82
 #, python-format
@@ -1824,11 +1830,6 @@ msgstr "Aucune vidéo trouvée"
 msgid "Edition of the channel"
 msgstr "Édition de la chaîne"
 
-#: pods/templates/channels/channel_edit.html:78
-#: pods/templates/mediacourses/mediacourses_add.html:53
-msgid "Warning, errors have been found in the form"
-msgstr "Attention, des erreurs ont été trouvées dans le formulaire"
-
 #: pods/templates/channels/channel_edit.html:95
 #: pods/templates/channels/channel_edit.html:96
 #: pods/templates/channels/channel_edit.html:176
@@ -1974,11 +1975,6 @@ msgstr "Recherche avancée"
 #: pods/templates/search/search.html:191
 msgid "faceting"
 msgstr "Affiner"
-
-#: pods/templates/videos/chapter/form_chapter.html:27
-#: pods/templates/videos/enrich/form_enrich.html:27
-msgid "Your form contains errors:"
-msgstr "Le formulaire contient des erreurs :"
 
 #: pods/templates/videos/chapter/list_chapter.html:26
 msgid "List of chapters"
@@ -2182,13 +2178,6 @@ msgstr "Erreur lors de l'enregistrement."
 #: pods/templates/videos/video_enrich.html:244
 msgid "No data could be stored."
 msgstr "Aucune données enregistrées"
-
-#: pods/templates/videos/video_chapter.html:257
-#: pods/templates/videos/video_enrich.html:248
-msgid "Errors found in the form, please correct it."
-msgstr ""
-"Des erreurs ont été trouvées dans le formulaire. Veuillez les corriger puis "
-"sauvegarder à nouveau."
 
 #: pods/templates/videos/video_chapter.html:273
 #: pods/templates/videos/video_enrich.html:268 pods/views.py:178
@@ -2398,10 +2387,6 @@ msgstr "Veuillez spécifier un type."
 #: pods/templates/videos/video_player.html:117
 msgid "The video is currently being encoded."
 msgstr "Cette vidéo est en cours d'encodage."
-
-#: pods/templates/videos/video_edit.html:176
-msgid "Errors have been found in the form."
-msgstr "Des erreurs ont été trouvées dans le formulaire."
 
 #: pods/templates/videos/video_edit.html:204
 msgid "Save and return to the previous page"

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-02 18:08+0200\n"
-"PO-Revision-Date: 2015-07-02 18:10+0200\n"
+"PO-Revision-Date: 2015-07-03 11:24+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -2146,7 +2146,7 @@ msgstr "Modifier la vidéo"
 #: pods/templates/videos/video_chapter.html:29
 #: pods/templates/videos/video_chapter.html:329
 #: pods/templates/videos/video_chapter.html:340
-msgid "Chaptering of the video"
+msgid "Chaptering the video"
 msgstr "Chapitrer la vidéo"
 
 #: pods/templates/videos/video_chapter.html:192

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-06-25 17:36+0200\n"
-"PO-Revision-Date: 2015-07-02 17:33+0200\n"
+"PO-Revision-Date: 2015-07-02 18:06+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -1529,7 +1529,7 @@ msgid "Kind"
 msgstr "Genre"
 
 #: pods/models.py:501
-msgid "sub-heading file"
+msgid "subtitle file"
 msgstr "fichier de sous-titres"
 
 #: pods/models.py:504
@@ -1937,7 +1937,7 @@ msgstr "Modifier les informations de la vidéo."
 #: pods/templates/search/search.html:148
 #: pods/templates/videos/ownertools.html:28
 #: pods/templates/videos/videos_list.html:89
-msgid "Add subheading, contributors, documents to download."
+msgid "Add subtitle files, contributors, documents to download."
 msgstr "Ajouter des sous-titres, contributeurs, documents à télécharger."
 
 #: pods/templates/search/search.html:176

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-07-02 18:08+0200\n"
-"PO-Revision-Date: 2015-07-03 13:53+0200\n"
+"PO-Revision-Date: 2015-07-03 14:15+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -1918,7 +1918,7 @@ msgstr "propriétaires"
 
 #: pods/templates/pagination.html:40
 msgid "Show all"
-msgstr "Afficher tous"
+msgstr "Tout afficher"
 
 #: pods/templates/search/search.html:136
 #: pods/templates/videos/ownertools.html:24

--- a/traduction/django.po
+++ b/traduction/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-25 17:36+0200\n"
-"PO-Revision-Date: 2015-07-02 18:06+0200\n"
+"POT-Creation-Date: 2015-07-02 18:08+0200\n"
+"PO-Revision-Date: 2015-07-02 18:10+0200\n"
 "Last-Translator: Philippe Pomédio <philippe.pomedio@unice.fr>\n"
 "Language-Team: LANGUAGE <nicolas.can@univ-lille1.fr>\n"
 "Language: fr\n"
@@ -292,6 +292,7 @@ msgstr "Supprimer '%(item_label)s'."
 #: pods/templates/search/search.html:153 pods/templates/search/search.html:155
 #: pods/templates/videos/chapter/list_chapter.html:55
 #: pods/templates/videos/enrich/list_enrich.html:60
+#: pods/templates/videos/ownertools.html:45
 #: pods/templates/videos/video_chapterpods_formset.html:133
 #: pods/templates/videos/video_chapterpods_formset.html:161
 #: pods/templates/videos/video_completion_formset.html:138
@@ -303,7 +304,6 @@ msgstr "Supprimer '%(item_label)s'."
 #: pods/templates/videos/video_delete.html:73
 #: pods/templates/videos/videos_list.html:101
 #: pods/templates/videos/videos_list.html:102
-#: pods/templates/videos/ownertools.html:45
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -627,7 +627,7 @@ msgstr "Effacer"
 
 #: core/templates/registration/login.html:116
 #: pods/templates/videos/my_videos.html:64
-#: pods/templates/videos/video_chapter.html:380
+#: pods/templates/videos/video_chapter.html:379
 #: pods/templates/videos/video_completion_formset.html:352
 #: pods/templates/videos/video_enrich.html:474
 msgid "Information"
@@ -1681,10 +1681,7 @@ msgstr "Début de la vidéo"
 msgid "Start time of the chapter, in seconds."
 msgstr "Début d'affichage du chapitre, en secondes."
 
-#: pods/models.py:696 pods/templates/search/search.html:140
-#: pods/templates/search/search.html:142
-#: pods/templates/videos/videos_list.html:92
-#: pods/templates/videos/videos_list.html:93
+#: pods/models.py:696
 msgid "Chapter"
 msgstr "Chapitre"
 
@@ -1900,7 +1897,7 @@ msgstr "Ajouter un nouvel enregistrement"
 #: pods/templates/videos/my_videos.html:24
 #: pods/templates/videos/my_videos.html:32
 #: pods/templates/videos/my_videos.html:43
-#: pods/templates/videos/video_chapter.html:340
+#: pods/templates/videos/video_chapter.html:339
 #: pods/templates/videos/video_chapterpods_formset.html:96
 #: pods/templates/videos/video_completion_formset.html:89
 #: pods/templates/videos/video_delete.html:35
@@ -1922,23 +1919,53 @@ msgstr "propriétaires"
 msgid "Show all"
 msgstr "Afficher tous"
 
-#: pods/templates/search/search.html:136 pods/templates/search/search.html:138
-#: pods/templates/search/search.html:179
+#: pods/templates/search/search.html:136
+#: pods/templates/videos/ownertools.html:24
 #: pods/templates/videos/videos_list.html:86
+msgid "Edit video information."
+msgstr "Modifier les informations de la vidéo."
+
+#: pods/templates/search/search.html:138 pods/templates/search/search.html:179
+#: pods/templates/videos/ownertools.html:25
 #: pods/templates/videos/videos_list.html:87
 msgid "Edit"
 msgstr "Modifier"
 
-#: pods/templates/videos/ownertools.html:24
-#: pods/templates/videos/ownertools.html:25
-msgid "Edit video information."
-msgstr "Modifier les informations de la vidéo."
-
-#: pods/templates/search/search.html:148
+#: pods/templates/search/search.html:140
 #: pods/templates/videos/ownertools.html:28
 #: pods/templates/videos/videos_list.html:89
 msgid "Add subtitle files, contributors, documents to download."
 msgstr "Ajouter des sous-titres, contributeurs, documents à télécharger."
+
+#: pods/templates/search/search.html:142
+#: pods/templates/videos/ownertools.html:29
+#: pods/templates/videos/videos_list.html:90
+msgid "Completion"
+msgstr "Complétion"
+
+#: pods/templates/search/search.html:144
+#: pods/templates/videos/ownertools.html:32
+#: pods/templates/videos/videos_list.html:92
+msgid "Divide the video into chapters."
+msgstr "Diviser la video en chapitres."
+
+#: pods/templates/search/search.html:146
+#: pods/templates/videos/ownertools.html:33
+#: pods/templates/videos/videos_list.html:93
+msgid "Chaptering"
+msgstr "Chapitrage"
+
+#: pods/templates/search/search.html:148
+#: pods/templates/videos/ownertools.html:36
+#: pods/templates/videos/videos_list.html:96
+msgid "Add enrichments to the video."
+msgstr "Ajouter des enrichissements à la vidéo."
+
+#: pods/templates/search/search.html:150
+#: pods/templates/videos/ownertools.html:37
+#: pods/templates/videos/videos_list.html:97
+msgid "Enrich"
+msgstr "Enrichir"
 
 #: pods/templates/search/search.html:176
 msgid "Advanced Search"
@@ -1980,31 +2007,6 @@ msgstr "Liste des enrichissements"
 msgid "Use the thumbnails toolbar to work on a video."
 msgstr "Utilisez la barre d'outils pour travailler sur une vidéo."
 
-#: pods/templates/videos/ownertools.html:29
-#: pods/templates/search/search.html:150
-#: pods/templates/videos/videos_list.html:90
-msgid "Completion"
-msgstr "Complétion"
-
-#: pods/templates/videos/ownertools.html:32
-msgid "Divide the video into chapters."
-msgstr "Diviser la video en chapitres."
-
-#: pods/templates/videos/ownertools.html:33
-msgid "Chaptering"
-msgstr "Chapitrage"
-
-#: pods/templates/videos/ownertools.html:36
-msgid "Add enrichments to the video."
-msgstr "Ajouter des enrichissements à la vidéo."
-
-#: pods/templates/videos/ownertools.html:37
-#: pods/templates/search/search.html:144 pods/templates/search/search.html:146
-#: pods/templates/videos/videos_list.html:96
-#: pods/templates/videos/videos_list.html:97
-msgid "Enrich"
-msgstr "Enrichir"
-
 #: pods/templates/videos/ownertools.html:40
 msgid "Watch the video."
 msgstr "Regarder la vidéo."
@@ -2016,13 +2018,6 @@ msgstr "Regarder"
 #: pods/templates/videos/ownertools.html:44
 msgid "Delete the video."
 msgstr "Supprimer la vidéo."
-
-#: pods/templates/videos/video_delete.html:26
-#: pods/templates/videos/video_delete.html:35
-#: pods/templates/videos/video_delete.html:41
-#: pods/templates/videos/video_delete.html:57
-msgid "Delete the video"
-msgstr "Supprimer la vidéo"
 
 #: pods/templates/videos/video.html:45 pods/templates/videos/video.html:78
 #: pods/templates/videos/video_chapter.html:183
@@ -2142,15 +2137,15 @@ msgid "You must be logged in to take notes."
 msgstr "Vous devez être connecté pour prendre des notes."
 
 #: pods/templates/videos/video.html:500
-#: pods/templates/videos/video_chapter.html:374
+#: pods/templates/videos/video_chapter.html:373
 #: pods/templates/videos/video_chapterpods_formset.html:208
 #: pods/templates/videos/video_enrich.html:468
 msgid "Edit the video"
 msgstr "Modifier la vidéo"
 
 #: pods/templates/videos/video_chapter.html:29
-#: pods/templates/videos/video_chapter.html:330
-#: pods/templates/videos/video_chapter.html:341
+#: pods/templates/videos/video_chapter.html:329
+#: pods/templates/videos/video_chapter.html:340
 msgid "Chaptering of the video"
 msgstr "Chapitrer la vidéo"
 
@@ -2223,11 +2218,11 @@ msgstr "commence en même temps."
 msgid "Get time from the player"
 msgstr "Récupérer le temps depuis le lecteur"
 
-#: pods/templates/videos/video_chapter.html:366
+#: pods/templates/videos/video_chapter.html:365
 msgid "Add a new chapter"
 msgstr "Ajouter un nouveau chapitre"
 
-#: pods/templates/videos/video_chapter.html:382
+#: pods/templates/videos/video_chapter.html:381
 msgid ""
 "\"Add a new chapter\" allows you to add a new chapter and \"delete\" allows "
 "you to remove the chapter"
@@ -2235,7 +2230,7 @@ msgstr ""
 "\"Ajouter un nouveau chapitre\" vous permet de créer un nouveau chapitre et "
 "\"supprimer\" vous permet de supprimer le chapitre"
 
-#: pods/templates/videos/video_chapter.html:383
+#: pods/templates/videos/video_chapter.html:382
 msgid ""
 "Start playback of the video, pause the video and click on \"Get time from "
 "the player\" to fill in the field intitled \"Start time\"."
@@ -2244,11 +2239,11 @@ msgstr ""
 "le temps depuis le lecteur\" pour renseigner automatiquement le champ "
 "\"début du chapitre\"."
 
-#: pods/templates/videos/video_chapter.html:384
+#: pods/templates/videos/video_chapter.html:383
 msgid "The chapters cannot start at the same time."
 msgstr "Les chapitres ne peuvent pas commencer en même temps."
 
-#: pods/templates/videos/video_chapter.html:385
+#: pods/templates/videos/video_chapter.html:384
 msgid "You must save your chapters to view the result."
 msgstr "Vous devez sauvegarder pour visualiser le résultat."
 
@@ -2347,6 +2342,13 @@ msgstr ""
 "Vos permissions actuelles ne vous permettent pas d'ajouter des fichiers de "
 "sous-titre ou des documents à télécharger à vos vidéos. Veuillez nous "
 "contacter pour vous ajouter ces droits"
+
+#: pods/templates/videos/video_delete.html:26
+#: pods/templates/videos/video_delete.html:35
+#: pods/templates/videos/video_delete.html:41
+#: pods/templates/videos/video_delete.html:57
+msgid "Delete the video"
+msgstr "Supprimer la vidéo"
 
 #: pods/templates/videos/video_delete.html:63
 msgid "Are you sure you want to delete the video"


### PR DESCRIPTION
• removed « fuzzy » from po file,
• same text for all « video action » menus,
• restoring « subtile » vs « subheading » (wrong trad. introduced in previous I18n/L10n request), 
• simplified forms error msgs,
• po file regeneration,
• other minor changes.